### PR TITLE
Add industry section, including rolodex effect

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -202,27 +202,34 @@
     <section>
       <div class="bg-white">
         <div class="max-width-container">
-          <div class="flex flex-col-reverse sm:flex-row justify-between my-20">
+          <div
+            class="flex flex-col-reverse sm:flex-row justify-between my-4 sm:my-20 gap-6"
+          >
             <div class="basis-2/5 text-center sm:text-left">
               <h1>Scaling <i>beyond</i> geospatial tech</h1>
-              <p class="large-body leading-8 my-6">
+              <p class="large-body leading-8 my-7">
                 Raster Vision is versatile and can seamlessly handle the
                 idiosyncrasies of working with massive image datasets across a
                 broad range of industries.
               </p>
               <a href="https://groundwork.azavea.com/"
-                ><div class="secondary-btn w-64 text-center">
-                  Build your custome pipeline
+                ><div class="secondary-btn w-64 text-center mx-auto sm:mx-0">
+                  Build your custom pipeline
                 </div></a
               >
             </div>
-            <div class="display h-16 overflow-hidden">
-              <ul class="animate-rolodex text-center">
+            <div class="display h-48 m-auto overflow-hidden lg:mr-28">
+              <!-- add bars to highlight only middle word in rolodex -->
+              <div class="rolodex-bars"></div>
+              <div class="rolodex-bars mt-24 rotate-180"></div>
+              <ul class="animate-rolodex text-center z-20">
+                <li>Forestry</li>
                 <li>Healthcare</li>
-                <li>Academic</li>
+                <li>Academia</li>
                 <li>Non-profit</li>
                 <li>Forestry</li>
                 <li>Healthcare</li>
+                <li>Academia</li>
               </ul>
             </div>
           </div>

--- a/src/index.html
+++ b/src/index.html
@@ -150,8 +150,8 @@
                     labeled.
                   </p>
                 </div>
-                <a href="https://github.com/azavea/raster-vision">
-                  <button class="secondary-btn hover:bg-gray-100">
+                <a href="https://groundwork.azavea.com/">
+                  <button class="secondary-btn">
                     Start training with GroundWork
                   </button>
                 </a>
@@ -174,9 +174,7 @@
                   </p>
                 </div>
                 <a href="https://docs.rastervision.io/">
-                  <button class="secondary-btn hover:bg-gray-100">
-                    Explore documentation
-                  </button>
+                  <button class="secondary-btn">Explore documentation</button>
                 </a>
               </div>
             </div>

--- a/src/index.html
+++ b/src/index.html
@@ -204,15 +204,29 @@
     <section>
       <div class="bg-white">
         <div class="max-width-container">
-          <div class="flex flex-col-reverse sm:flex-row sm:gap-20">
-            <div class="basis-1/2 text-center sm:text-left">
+          <div class="flex flex-col-reverse sm:flex-row justify-between my-20">
+            <div class="basis-2/5 text-center sm:text-left">
               <h1>Scaling <i>beyond</i> geospatial tech</h1>
-              <p class="medium-body">
-                Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do
-                eiusmod tempor incididunt ut labore et dolore magna aliqua.
+              <p class="large-body leading-8 my-6">
+                Raster Vision is versatile and can seamlessly handle the
+                idiosyncrasies of working with massive image datasets across a
+                broad range of industries.
               </p>
+              <a href="https://groundwork.azavea.com/"
+                ><div class="secondary-btn w-64 text-center">
+                  Build your custome pipeline
+                </div></a
+              >
             </div>
-            <img src="images/placeholder.svg" class="mx-auto sm:m-0 max-h-48" />
+            <div class="display h-16 overflow-hidden">
+              <ul class="animate-rolodex text-center">
+                <li>Healthcare</li>
+                <li>Academic</li>
+                <li>Non-profit</li>
+                <li>Forestry</li>
+                <li>Healthcare</li>
+              </ul>
+            </div>
           </div>
         </div>
       </div>

--- a/src/input.css
+++ b/src/input.css
@@ -27,6 +27,10 @@
   @apply bg-gradient-to-r from-gradient-left to-gradient-right;
 }
 
+.li::before {
+  @apply content-none;
+}
+
 @layer base {
   h1 {
     @apply font-normal text-3xl text-black;
@@ -48,7 +52,7 @@
   }
 
   .secondary-btn {
-    @apply rounded bg-white text-black border-gray-button border-1 p-2;
+    @apply rounded bg-white text-black border-gray-button border-1 p-2 hover:bg-gray-100;
   }
 
   .max-width-container {

--- a/src/input.css
+++ b/src/input.css
@@ -27,10 +27,6 @@
   @apply bg-gradient-to-r from-gradient-left to-gradient-right;
 }
 
-.li::before {
-  @apply content-none;
-}
-
 @layer base {
   h1 {
     @apply font-normal text-3xl text-black;
@@ -69,6 +65,10 @@
 
   .hero-external-buttons {
     @apply bg-gray-100 p-3.5 w-80 rounded-xl cursor-pointer mb-3 sm:w-64;
+  }
+
+  .rolodex-bars {
+    @apply absolute bg-gradient-to-b from-white via-white opacity-80 h-24 z-30 w-80;
   }
 }
 

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -92,7 +92,7 @@ module.exports = {
         },
       },
       animation: {
-        rolodex: "roll 16s cubic-bezier(.75,0,.25,1) infinite",
+        rolodex: "roll 15s cubic-bezier(.75,0,.25,1) infinite",
       },
     },
   },

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -82,6 +82,18 @@ module.exports = {
       lineHeight: {
         display: "64px",
       },
+      keyframes: {
+        roll: {
+          "0%": { transform: "translateY(0)" },
+          "25%": { transform: "translateY(-64px)" },
+          "50%": { transform: "translateY(-128px)" },
+          "75%": { transform: "translateY(-192px)" },
+          "100%": { transform: "translateY(-256px)" },
+        },
+      },
+      animation: {
+        rolodex: "roll 16s cubic-bezier(.75,0,.25,1) infinite",
+      },
     },
   },
   plugins: [],


### PR DESCRIPTION
**Overview**

This PR adds the industry section, including the copy, button, and rolodex effect. It also performs a quick cleanup on the buttons in the "How it Works" section by consolidating the hover state on the secondary button into the class rather than on each button and updates the link on the "Start training with Groundwork" button.

**Demo**

https://user-images.githubusercontent.com/77936689/205688734-938cd6dd-9237-4ffd-8db5-68fcfe1c5fd7.mov

**Notes**

I built the rolodex via CSS animation and then found it was really difficult to combine that method with programmatically changing the opacity of each word as it moves in and out of the middle. So I decided to mimic the effect by adding two boxes with a gradient from white to transparent and opacity of 80% to sit over the top and bottom words. This isn't perfect, but it gets very close and felt like a better use of time than trying to restart on solving the problem in a way to allow programmatic opacity changes. I can explore other methods later if needed and there is time to do so.

Resolves #17 