### PR TITLE
Reorganize Tailwind header styling out of <h> tags

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -102,11 +102,13 @@
             </div>
             <div class="sm:h-40"></div>
             <div class="max-w-header-text z-40 min-h-hero-text">
-              <h2 class="text-lg sm:text-2xl">An open-source ML library for</h2>
-              <p
+              <h1 class="text-lg sm:text-2xl medium-headline">
+                An open-source ML library for
+              </h1>
+              <h1
                 id="hero-text"
                 class="display mt-2 text-3xl leading-tight sm:text-4xl"
-              ></p>
+              ></h1>
             </div>
             <div class="h-2 sm:h-10"></div>
             <div class="flex gap-3 top-8 sm:top-32">
@@ -137,20 +139,22 @@
             >
               <a href="https://github.com/azavea/raster-vision">
                 <div class="hero-external-buttons group">
-                  <h1 class="group-hover:text-teal">Get started</h1>
-                  <h4>GitHub Repo</h4>
+                  <p class="group-hover:text-teal large-headline">
+                    Get started
+                  </p>
+                  <p class="small-headline-all-caps">GitHub Repo</p>
                 </div>
               </a>
               <a href="https://docs.rastervision.io/">
                 <div class="hero-external-buttons group">
-                  <h1 class="group-hover:text-teal">Explore</h1>
-                  <h4>Documentation</h4>
+                  <p class="group-hover:text-teal large-headline">Explore</p>
+                  <p class="small-headline-all-caps">Documentation</p>
                 </div>
               </a>
               <a href="https://github.com/azavea/raster-vision/discussions">
                 <div class="hero-external-buttons group">
-                  <h1 class="group-hover:text-teal">Discuss</h1>
-                  <h4>GitHub Discussions</h4>
+                  <p class="group-hover:text-teal large-headline">Discuss</p>
+                  <p class="small-headline-all-caps">GitHub Discussions</p>
                 </div>
               </a>
             </div>
@@ -163,10 +167,10 @@
         <div class="max-width-container">
           <div class="mt-14 sm:flex sm:flex-row sm:mt-0 gap-10">
             <div class="basis-1/2 my-auto">
-              <h1 class="text-2xl text-white mb-6 md:text-3xl">
+              <h2 class="large-heading text-2xl text-white mb-6 md:text-3xl">
                 Build intelligent <i>geospatial</i> applications with deep
                 learning.
-              </h1>
+              </h2>
               <p class="medium-body text-white">
                 Raster Vision is an open source library and framework that
                 bridges the divide between the world of GIS and deep
@@ -190,10 +194,10 @@
     <section>
       <div class="bg-white-0">
         <div class="max-width-container text-center mt-10">
-          <h4>How it Works</h4>
-          <h1 class="text-2xl sm:text-3xl">
+          <h2 class="small-headline-all-caps">How it Works</h2>
+          <h3 class="text-2xl sm:text-3xl large-headline">
             Introducing the Raster Vision pipeline
-          </h1>
+          </h3>
           <p class="small-body text-gray-700">
             Example is showing a semantic segmentation task
           </p>
@@ -210,7 +214,9 @@
                 class="sm:h-72 md:h-64 lg:h-44 flex flex-col justify-between mx-6 sm:mx-0"
               >
                 <div>
-                  <h3><span class="text-teal">01</span> Data input</h3>
+                  <h4 class="small-headline">
+                    <span class="text-teal">01</span> Data input
+                  </h4>
                   <p class="medium-body my-4 md:my-0">
                     Input set of images and training data, optionally with Areas
                     of Interest (AOIs) that describe where the images are
@@ -236,9 +242,9 @@
                 class="sm:h-72 md:h-64 lg:h-44 flex flex-col justify-between mx-6 sm:mx-0"
               >
                 <div>
-                  <h3>
+                  <h4 class="small-headline">
                     <span class="text-teal">02</span> Raster Vision pipeline
-                  </h3>
+                  </h4>
                   <p class="medium-body my-4 md:my-0">
                     The computer vision pipeline configuration documentation is
                     easy to read, reuse, and maintain.
@@ -261,7 +267,9 @@
                 class="sm:h-72 md:h-64 lg:h-44 flex flex-col justify-between mx-6 sm:mx-0"
               >
                 <div>
-                  <h3><span class="text-teal">03</span> Deployment</h3>
+                  <h4 class="small-headline">
+                    <span class="text-teal">03</span> Deployment
+                  </h4>
                   <p class="medium-body my-4 md:my-0">
                     Model bundle is deployed in batch processes, live servers,
                     and other custom workflows.
@@ -281,9 +289,9 @@
             class="flex flex-col-reverse md:flex-row justify-between my-6 sm:my-10 md:my-20 gap-6"
           >
             <div class="basis-2/5 text-center md:text-left">
-              <h1 class="text-2xl sm:text-3xl">
+              <h3 class="text-2xl sm:text-3xl large-heading">
                 Scaling <i>beyond</i> geospatial tech
-              </h1>
+              </h3>
               <p class="large-body leading-8 my-7">
                 Raster Vision is versatile and can seamlessly handle the
                 idiosyncrasies of working with massive image datasets across a
@@ -336,7 +344,9 @@
             </button>
           </div>
           <div id="spec-section" class="hidden sm:block sm:mb-28">
-            <h1 class="text-center text-white">Technical specifications</h1>
+            <h2 class="large-headline text-center text-white">
+              Technical specifications
+            </h2>
             <div class="sm:grid sm:grid-cols-2 md:grid-cols-3">
               <div class="tech-spec text-white">
                 <img
@@ -344,10 +354,10 @@
                   alt=""
                   class="tech-spec-icon"
                 />
-                <p class="font-semibold text-med">
+                <h4 class="font-semibold text-med">
                   Offers a complete training pipeline for three computer vision
                   tasks
-                </p>
+                </h4>
                 <p>
                   Including chip classification, object detection, and semantic
                   segmentation.
@@ -359,9 +369,9 @@
                   alt=""
                   class="tech-spec-icon"
                 />
-                <p class="font-semibold text-med">
+                <h4 class="font-semibold text-med">
                   Produces georeferenced outputs
-                </p>
+                </h4>
                 <p>
                   Raster Vision produces predictions that are georeferenced and
                   ready for downstream analysis.
@@ -373,9 +383,9 @@
                   alt=""
                   class="tech-spec-icon"
                 />
-                <p class="font-semibold text-med">
+                <h4 class="font-semibold text-med">
                   Restrict training chips to an area or interest (AOI)
-                </p>
+                </h4>
                 <p>
                   Fully annotating a large pixel scene is costly and time
                   consuming. Raster Vision supports specifying an AOI in the
@@ -388,7 +398,9 @@
                   alt=""
                   class="tech-spec-icon"
                 />
-                <p class="font-semibold text-med">Facilitates data wrangling</p>
+                <h4 class="font-semibold text-med">
+                  Facilitates data wrangling
+                </h4>
                 <p>
                   Raster Vision can ingest both raster and vector data and
                   convert them to a form suitable for training.
@@ -396,10 +408,10 @@
               </div>
               <div class="tech-spec text-white">
                 <img src="images/send-back.svg" alt="" class="tech-spec-icon" />
-                <p class="font-semibold text-med">
+                <h4 class="font-semibold text-med">
                   Supports multiband imagery (eg. RGBIR images, Sentinel 2
                   imagery)
-                </p>
+                </h4>
                 <p>
                   While retaining the existing pre-trained weights, Raster
                   Vision modifies the first convolutional layer to accept
@@ -408,7 +420,7 @@
               </div>
               <div class="tech-spec text-white">
                 <img src="images/aperture.svg" alt="" class="tech-spec-icon" />
-                <p class="font-semibold text-med">Offers data augmentation</p>
+                <h4 class="font-semibold text-med">Offers data augmentation</h4>
                 <p>
                   Raster Vision supports customizable Albumentations transforms
                   to use during training.
@@ -420,7 +432,9 @@
                   alt=""
                   class="tech-spec-icon"
                 />
-                <p class="font-semibold text-med">Custom model specification</p>
+                <h4 class="font-semibold text-med">
+                  Custom model specification
+                </h4>
                 <p>
                   Utilize a wide variety of compatible models from local
                   directories using TorchHub.
@@ -428,7 +442,7 @@
               </div>
               <div class="tech-spec text-white">
                 <img src="images/flame.svg" alt="" class="tech-spec-icon" />
-                <p class="font-semibold text-med">Based on PyTorch</p>
+                <h4 class="font-semibold text-med">Based on PyTorch</h4>
                 <p>
                   Raster Vision implements deep learning functionality with
                   PyTorch (a popular deep learning library) and Torchvision.
@@ -440,9 +454,9 @@
                   alt=""
                   class="tech-spec-icon"
                 />
-                <p class="font-semibold text-med">
+                <h4 class="font-semibold text-med">
                   Supports running pipelines in the cloud
-                </p>
+                </h4>
                 <p>
                   Raster Vision provides support for running pipelines using AWS
                   Batch.
@@ -454,9 +468,9 @@
                   alt=""
                   class="tech-spec-icon"
                 />
-                <p class="font-semibold text-med">
+                <h4 class="font-semibold text-med">
                   Supports configurable chip reading
-                </p>
+                </h4>
                 <p>
                   Geospatial images tend to be too large to feed directly into a
                   neural network and must first be broken up into smaller
@@ -466,9 +480,9 @@
             </div>
           </div>
           <div class="text-center mb-8 mt-2 sm:mt-0">
-            <h2 class="text-white">
+            <h3 class="text-white medium-headline">
               Built on popular technologies & open source libraries including
-            </h2>
+            </h3>
             <p class="large-body text-white pb-4">
               AWS (S3 and Batch), PyTorch, TorchVision, Albumentations,
               Rasterio, Shapely, Gdal and Numpy.
@@ -511,10 +525,12 @@
       <div class="bg-white-50">
         <div class="max-width-container">
           <div class="text-center my-14">
-            <h4>Why Use Raster Vision</h4>
-            <h1 class="max-w-2xl mx-auto mb-8 text-2xl sm:text-3xl">
+            <h2 class="small-headline-all-caps">Why Use Raster Vision</h2>
+            <h3
+              class="max-w-2xl mx-auto mb-8 text-2xl sm:text-3xl large-headline"
+            >
               Employ extraordinary data processing power to meet your goals.
-            </h1>
+            </h3>
             <div class="grid grid-cols-2 md:grid-cols-4 gap-x-3 gap-y-8">
               <div>
                 <img
@@ -522,7 +538,7 @@
                   alt=""
                   src="images/why-use-customizable.jpg"
                 />
-                <p class="why-use-headline"><strong>Customizable</strong></p>
+                <h4 class="why-use-headline"><strong>Customizable</strong></h4>
                 <p class="xsmall-body text-gray-700">
                   Utilize custom datasets, model architectures, and arbitrary
                   loss functions.
@@ -534,9 +550,9 @@
                   alt=""
                   src="images/why-use-repeatable.jpg"
                 />
-                <p class="why-use-headline">
+                <h4 class="why-use-headline">
                   <strong>Repeatable, configurable workflow</strong>
-                </p>
+                </h4>
                 <p class="xsmall-body text-gray-700">
                   Create consistent and maintainable results.
                 </p>
@@ -547,7 +563,7 @@
                   alt=""
                   src="images/why-use-opensource.jpg"
                 />
-                <p class="why-use-headline"><strong>Open source</strong></p>
+                <h4 class="why-use-headline"><strong>Open source</strong></h4>
                 <p class="xsmall-body text-gray-700">
                   Benefit from a constantly updated & supported framework
                   released under the open source Apache 2.0 license.
@@ -559,9 +575,9 @@
                   alt=""
                   src="images/why-use-geodatasets.jpg"
                 />
-                <p class="why-use-headline">
+                <h4 class="why-use-headline">
                   <strong>Handles geospatial datasets</strong>
-                </p>
+                </h4>
                 <p class="xsmall-body text-gray-700">
                   Handles a variety of geospatial file formats, map-based
                   coordinates, incomplete labeling, and multiband (3+ bands)
@@ -574,9 +590,9 @@
                   alt=""
                   src="images/why-use-massiveimgagery.jpg"
                 />
-                <p class="why-use-headline">
+                <h4 class="why-use-headline">
                   <strong>Supports massive imagery</strong>
-                </p>
+                </h4>
                 <p class="xsmall-body text-gray-700">
                   Works out-of-the-box with massive imagery commonly used in the
                   geospatial field.
@@ -588,9 +604,9 @@
                   alt=""
                   src="images/why-use-lowbarrier.jpg"
                 />
-                <p class="why-use-headline">
+                <h4 class="why-use-headline">
                   <strong>Low barrier to entry</strong>
-                </p>
+                </h4>
                 <p class="xsmall-body text-gray-700">
                   Enjoy a high-level programmatic API with sensible defaults for
                   configuring modeling pipelines. Doesn't require expertise in
@@ -603,9 +619,9 @@
                   alt=""
                   src="images/why-use-fastaws.jpg"
                 />
-                <p class="why-use-headline">
+                <h4 class="why-use-headline">
                   <strong>Fast AWS Batch setup process</strong>
-                </p>
+                </h4>
                 <p class="xsmall-body text-gray-700">
                   Skip the manual setup and use CloudFormation templates.
                 </p>
@@ -616,9 +632,9 @@
                   alt=""
                   src="images/why-use-extensible.jpg"
                 />
-                <p class="why-use-headline">
+                <h4 class="why-use-headline">
                   <strong>Extensible architecture</strong>
-                </p>
+                </h4>
                 <p class="xsmall-body text-gray-700">
                   Object-oriented architecture is extendable to new computer
                   vision tasks and deep learning frameworks.
@@ -639,10 +655,10 @@
             <div
               class="mb-10 h-fit md:mb-0 rounded-lg sm:min-w-repeatable-config-text-narrow bg-white-100 p-6 sm:p-2 md:p-6 basis-1/3"
             >
-              <h1 class="text-2xl md:text-3xl">
+              <h3 class="text-2xl md:text-3xl large-headline">
                 Quick & repeatable configurations
-              </h1>
-              <h4 class="mt-6 mb-5">Select a scenario</h4>
+              </h3>
+              <p class="small-headline-all-caps mt-6 mb-5">Select a scenario</p>
               <div class="flex flex-col gap-3">
                 <div
                   id="repeatable-config-0"
@@ -743,7 +759,7 @@
         <div class="max-width-container pt-10 md:pt-28 pb-0">
           <div class="md:flex md:flex-row-reverse md:justify-between gap-4">
             <div class="basis-1/2">
-              <h1 class="text-white">How can we help?</h1>
+              <h3 class="large-headline text-white">How can we help?</h3>
               <p class="large-body text-white">
                 Please select a topic below or fill out our contact form related
                 to your inquiry.
@@ -751,7 +767,7 @@
               <a href="https://github.com/azavea/raster-vision/discussions">
                 <div class="contact-us-option mt-4">
                   <div class="contact-us-text">
-                    <p class="large-body text-blue">Join the discussion!</p>
+                    <h4 class="large-body text-blue">Join the discussion!</h4>
                     <p class="medium-body text-gray-200">
                       Let us know what you're working on! You can ask questions
                       and talk to developers.
@@ -767,7 +783,7 @@
               <a href="https://docs.rastervision.io/en/0.13/CONTRIBUTING.html">
                 <div class="contact-us-option">
                   <div class="contact-us-text">
-                    <p class="large-body text-blue">Contribute</p>
+                    <h4 class="large-body text-blue">Contribute</h4>
                     <p class="medium-body text-gray-200">
                       We are happy to take contributions! It is best to get in
                       touch about larger features or design changes.
@@ -783,7 +799,7 @@
               <a href="https://www.azavea.com/projects/">
                 <div class="contact-us-option">
                   <div class="contact-us-text">
-                    <p class="large-body text-blue">Get inspired</p>
+                    <h4 class="large-body text-blue">Get inspired</h4>
                     <p class="medium-body text-gray-200">
                       Browse through a series of machine learning projects
                       produced by Azavea Inc.
@@ -892,9 +908,9 @@
                 ></div>
               </form>
               <div id="success-msg" class="hidden">
-                <h1 class="text-white text-center md:text-left">
+                <h4 class="text-white text-center md:text-left">
                   Message sent!
-                </h1>
+                </h4>
                 <p class="large-body text-white text-center md:text-left">
                   Someone will get back to you shortly.
                 </p>
@@ -912,13 +928,13 @@
     <section>
       <div class="bg-blue-900">
         <div class="max-width-container">
-          <h2 class="text-white text-center mt-4 sm:mt-8">
+          <p class="medium-headline text-white text-center mt-4 sm:mt-8">
             An open-source computer vision and machine-learning framework
             developed by
             <a href="https://www.azavea.com/"
               ><span class="text-blue underline">Azavea</span></a
             >.
-          </h2>
+          </p>
           <div
             class="flex flex-col-reverse sm:flex-row justify-center text-center xsmall-body text-white mt-16"
           >

--- a/src/input.css
+++ b/src/input.css
@@ -19,23 +19,20 @@
   @apply font-normal text-4xl leading-display text-teal;
 }
 
-.h3-blue {
-  @apply font-semibold text-lg text-teal;
+.large-headline {
+  @apply font-normal text-3xl text-black;
 }
 
-@layer base {
-  h1 {
-    @apply font-normal text-3xl text-black;
-  }
-  h2 {
-    @apply font-normal text-2xl text-black;
-  }
-  h3 {
-    @apply font-semibold text-lg text-black;
-  }
-  h4 {
-    @apply font-semibold text-med uppercase text-gray-700;
-  }
+.medium-headline {
+  @apply font-normal text-2xl text-black;
+}
+
+.small-headline {
+  @apply font-semibold text-lg text-black;
+}
+
+.small-headline-all-caps {
+  @apply font-semibold text-med uppercase text-gray-700;
 }
 
 @layer components {


### PR DESCRIPTION
**Overview**

This PR improves screen reader accessibility by moving the header styling out of the `<h1>`-`<h4>` tags and into separate classes. It then adds a more appropriate header hierarchy for improved screen reader accessibility.

Resolves #44 