### PR TITLE
Fix missing links & replace empty alt tags with aria-hidden=true

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -88,7 +88,8 @@
           <img
             src="images/hero-crophealth2.png"
             alt="Aerial view of fields of crops"
-            class="hero-image secondary hidden aria-hidden"
+            class="hero-image secondary hidden"
+            aria-hidden="true"
             id="hero-img-1"
           />
         </div>
@@ -352,8 +353,8 @@
               <div class="tech-spec text-white">
                 <img
                   src="images/timeline-arrow.svg"
-                  alt=""
                   class="tech-spec-icon"
+                  aria-hidden="true"
                 />
                 <h4 class="font-semibold text-med">
                   Offers a complete training pipeline for three computer vision
@@ -367,8 +368,8 @@
               <div class="tech-spec text-white">
                 <img
                   src="images/circle-location-arrow.svg"
-                  alt=""
                   class="tech-spec-icon"
+                  aria-hidden="true"
                 />
                 <h4 class="font-semibold text-med">
                   Produces georeferenced outputs
@@ -381,8 +382,8 @@
               <div class="tech-spec text-white">
                 <img
                   src="images/draw-square.svg"
-                  alt=""
                   class="tech-spec-icon"
+                  aria-hidden="true"
                 />
                 <h4 class="font-semibold text-med">
                   Restrict training chips to an area or interest (AOI)
@@ -396,8 +397,8 @@
               <div class="tech-spec text-white">
                 <img
                   src="images/hat-cowboy.svg"
-                  alt=""
                   class="tech-spec-icon"
+                  aria-hidden="true"
                 />
                 <h4 class="font-semibold text-med">
                   Facilitates data wrangling
@@ -408,7 +409,11 @@
                 </p>
               </div>
               <div class="tech-spec text-white">
-                <img src="images/send-back.svg" alt="" class="tech-spec-icon" />
+                <img
+                  src="images/send-back.svg"
+                  class="tech-spec-icon"
+                  aria-hidden="true"
+                />
                 <h4 class="font-semibold text-med">
                   Supports multiband imagery (eg. RGBIR images, Sentinel 2
                   imagery)
@@ -420,7 +425,11 @@
                 </p>
               </div>
               <div class="tech-spec text-white">
-                <img src="images/aperture.svg" alt="" class="tech-spec-icon" />
+                <img
+                  src="images/aperture.svg"
+                  class="tech-spec-icon"
+                  aria-hidden="true"
+                />
                 <h4 class="font-semibold text-med">Offers data augmentation</h4>
                 <p>
                   Raster Vision supports customizable Albumentations transforms
@@ -430,8 +439,8 @@
               <div class="tech-spec text-white">
                 <img
                   src="images/diagram-sankey.svg"
-                  alt=""
                   class="tech-spec-icon"
+                  aria-hidden="true"
                 />
                 <h4 class="font-semibold text-med">
                   Custom model specification
@@ -442,7 +451,11 @@
                 </p>
               </div>
               <div class="tech-spec text-white">
-                <img src="images/flame.svg" alt="" class="tech-spec-icon" />
+                <img
+                  src="images/flame.svg"
+                  class="tech-spec-icon"
+                  aria-hidden="true"
+                />
                 <h4 class="font-semibold text-med">Based on PyTorch</h4>
                 <p>
                   Raster Vision implements deep learning functionality with
@@ -452,8 +465,8 @@
               <div class="tech-spec text-white">
                 <img
                   src="images/cloud-word.svg"
-                  alt=""
                   class="tech-spec-icon"
+                  aria-hidden="true"
                 />
                 <h4 class="font-semibold text-med">
                   Supports running pipelines in the cloud
@@ -466,8 +479,8 @@
               <div class="tech-spec text-white">
                 <img
                   src="images/table-cells-large.svg"
-                  alt=""
                   class="tech-spec-icon"
+                  aria-hidden="true"
                 />
                 <h4 class="font-semibold text-med">
                   Supports configurable chip reading
@@ -583,8 +596,8 @@
               <div>
                 <img
                   class="rounded-lg"
-                  alt=""
                   src="images/why-use-customizable.jpg"
+                  aria-hidden="true"
                 />
                 <h4 class="why-use-headline"><strong>Customizable</strong></h4>
                 <p class="xsmall-body text-gray-700">
@@ -595,8 +608,8 @@
               <div>
                 <img
                   class="rounded-lg"
-                  alt=""
                   src="images/why-use-repeatable.jpg"
+                  aria-hidden="true"
                 />
                 <h4 class="why-use-headline">
                   <strong>Repeatable, configurable workflow</strong>
@@ -608,8 +621,8 @@
               <div>
                 <img
                   class="rounded-lg"
-                  alt=""
                   src="images/why-use-opensource.jpg"
+                  aria-hidden="true"
                 />
                 <h4 class="why-use-headline"><strong>Open source</strong></h4>
                 <p class="xsmall-body text-gray-700">
@@ -620,8 +633,8 @@
               <div>
                 <img
                   class="rounded-lg"
-                  alt=""
                   src="images/why-use-geodatasets.jpg"
+                  aria-hidden="true"
                 />
                 <h4 class="why-use-headline">
                   <strong>Handles geospatial datasets</strong>
@@ -635,8 +648,8 @@
               <div>
                 <img
                   class="rounded-lg"
-                  alt=""
                   src="images/why-use-massiveimgagery.jpg"
+                  aria-hidden="true"
                 />
                 <h4 class="why-use-headline">
                   <strong>Supports massive imagery</strong>
@@ -649,8 +662,8 @@
               <div>
                 <img
                   class="rounded-lg"
-                  alt=""
                   src="images/why-use-lowbarrier.jpg"
+                  aria-hidden="true"
                 />
                 <h4 class="why-use-headline">
                   <strong>Low barrier to entry</strong>
@@ -664,8 +677,8 @@
               <div>
                 <img
                   class="rounded-lg"
-                  alt=""
                   src="images/why-use-fastaws.jpg"
+                  aria-hidden="true"
                 />
                 <h4 class="why-use-headline">
                   <strong>Fast AWS Batch setup process</strong>
@@ -677,8 +690,8 @@
               <div>
                 <img
                   class="rounded-lg"
-                  alt=""
                   src="images/why-use-extensible.jpg"
+                  aria-hidden="true"
                 />
                 <h4 class="why-use-headline">
                   <strong>Extensible architecture</strong>
@@ -791,7 +804,7 @@
               <img
                 id="legend"
                 class="absolute"
-                alt=""
+                aria-hidden="true"
                 src="images/demo-segsem-legend.svg"
               />
               <img
@@ -971,7 +984,11 @@
           <div
             class="relative flex object-bottom h-lets-chat-small sm:h-lets-chat mt-20 sm:mt-0 justify-center"
           >
-            <img src="images/letschat.svg" alt="" class="absolute bottom-0" />
+            <img
+              src="images/letschat.svg"
+              aria-hidden="true"
+              class="absolute bottom-0"
+            />
           </div>
         </div>
       </div>

--- a/src/index.html
+++ b/src/index.html
@@ -38,11 +38,12 @@
         class="flex flex-row max-width-container h-16 sm:h-24 items-center px-4 sm:px-2 md:px-8 lg:px-0 justify-between"
       >
         <div class="basis-1/2 sm:basis-1/3">
-          <img
-            src="images/rv-logo.svg"
-            alt="Raster Vision logo"
-            class="relative h-6"
-          />
+          <a href="#"
+            ><img
+              src="images/rv-logo.svg"
+              alt="Raster Vision logo"
+              class="relative h-6"
+          /></a>
         </div>
         <div class="flex flex-row items-center">
           <a href="https://github.com/azavea/raster-vision/discussions">
@@ -484,14 +485,61 @@
               Built on popular technologies & open source libraries including
             </h3>
             <p class="large-body text-white pb-4">
-              AWS (S3 and Batch), PyTorch, TorchVision, Albumentations,
-              Rasterio, Shapely, Gdal and Numpy.
+              AWS (<span class="hover:underline"
+                ><a href="https://aws.amazon.com/s3/" target="_blank"
+                  >S3</a
+                ></span
+              >
+              and
+              <span class="hover:underline"
+                ><a href="https://aws.amazon.com/batch/" target="_blank"
+                  >Batch</a
+                ></span
+              >),
+              <span class="hover:underline"
+                ><a href="https://pytorch.org/" target="_blank"
+                  >PyTorch</a
+                ></span
+              >,
+              <span class="hover:underline"
+                ><a
+                  href="https://pytorch.org/vision/stable/index.html"
+                  target="_blank"
+                  >TorchVision</a
+                ></span
+              >,
+              <span class="hover:underline"
+                ><a href="https://albumentations.ai/" target="_blank"
+                  >Albumentations</a
+                ></span
+              >,
+              <span class="hover:underline"
+                ><a
+                  href="https://rasterio.readthedocs.io/en/latest/"
+                  target="_blank"
+                  >Rasterio</a
+                ></span
+              >,
+              <span class="hover:underline"
+                ><a
+                  href="https://shapely.readthedocs.io/en/stable/index.html"
+                  target="_blank"
+                  >Shapely</a
+                ></span
+              >,
+              <span class="hover:underline"
+                ><a href="https://gdal.org/" target="_blank">Gdal</a></span
+              >
+              and
+              <span class="hover:underline"
+                ><a href="https://numpy.org/" target="_blank">Numpy</a></span
+              >.
             </p>
             <div
               class="grid grid-cols-2 max-w-xs sm:grid-cols-4 sm:gap-x-16 sm:max-w-xl m-auto place-items-center"
             >
               <div class="tech-spec-logo">
-                <a href="https://aws.amazon.com/">
+                <a href="https://aws.amazon.com/" target="_blank">
                   <img
                     src="images/logo-aws.svg"
                     alt="Amazon Web Services logo"
@@ -499,12 +547,12 @@
                 </a>
               </div>
               <div class="tech-spec-logo">
-                <a href="https://pytorch.org/">
+                <a href="https://pytorch.org/" target="_blank">
                   <img src="images/logo-pytorch.svg" alt="PyTorch logo" />
                 </a>
               </div>
               <div class="tech-spec-logo">
-                <a href="https://albumentations.ai/">
+                <a href="https://albumentations.ai/" target="_blank">
                   <img
                     src="images/logo-abulmentations.svg"
                     alt="Albumentations logo"
@@ -512,7 +560,7 @@
                 </a>
               </div>
               <div class="tech-spec-logo">
-                <a href="https://numpy.org/">
+                <a href="https://numpy.org/" target="_blank">
                   <img src="images/logo-numpy.svg" alt="Numpy logo" />
                 </a>
               </div>
@@ -704,7 +752,10 @@
                 </div>
               </div>
               <p class="small-body text-gray-700 mt-6">
-                Based on open-source data.
+                Based on
+                <a href="https://docs.rastervision.io/en/0.20/index.html"
+                  ><u>open-source data</u></a
+                >.
               </p>
             </div>
             <div


### PR DESCRIPTION
**Overview**

This PR accomplishes 2 things: 
- Adds in the missing links and on click behavior, including for the libraries in the technical specifications section, a link to Raster Vision's open source data, and returning to the top of the page on logo click
- Replaces the empty alt tags on decorative images that were added as a part of PR #45 with `aria-hidden="true"` to improve the screen reader experience

Resolves #42 