### PR TITLE
Fix industry rolodex speed and size

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -320,35 +320,52 @@
                 <li>Healthcare</li>
                 <li>Academia</li>
                 <li>Supply Chain</li>
-                <li class="hidden sm:block md:hidden lg:block">
+                <li
+                  class="hidden sm:block md:hidden lg:block"
+                  aria-hidden="true"
+                >
                   Energy Transition
                 </li>
+                <!--Add screen-reader-only versions that ignore screen size-->
+                <li class="sr-only">Energy Transition</li>
                 <li class="sm:hidden md:block lg:hidden" aria-hidden="true">
                   Clean Energy
                 </li>
-                <li class="hidden sm:block md:hidden lg:block">
+                <li
+                  class="hidden sm:block md:hidden lg:block"
+                  aria-hidden="true"
+                >
                   Oceans & Water
                 </li>
+                <li class="sr-only">Oceans & Water</li>
                 <li class="sm:hidden md:block lg:hidden" aria-hidden="true">
                   Waterways
                 </li>
-                <li class="hidden sm:block md:hidden lg:block">
+                <li
+                  class="hidden sm:block md:hidden lg:block"
+                  aria-hidden="true"
+                >
                   Climate Adaptation
                 </li>
+                <li class="sr-only">Climate Adaptation</li>
                 <li class="sm:hidden md:block lg:hidden" aria-hidden="true">
                   Climate
                 </li>
                 <li>Non-profit</li>
                 <li>Agriculture</li>
-                <li class="hidden sm:block md:hidden lg:block">
+                <li
+                  class="hidden sm:block md:hidden lg:block"
+                  aria-hidden="true"
+                >
                   Artificial Intelligence
                 </li>
+                <li class="sr-only">Artificial Intelligence</li>
                 <li class="sm:hidden md:block lg:hidden" aria-hidden="true">
                   AI
                 </li>
-                <li>Forestry</li>
-                <li>Healthcare</li>
-                <li>Academia</li>
+                <li aria-hidden="true">Forestry</li>
+                <li aria-hidden="true">Healthcare</li>
+                <li aria-hidden="true">Academia</li>
               </ul>
             </div>
           </div>

--- a/src/index.html
+++ b/src/index.html
@@ -292,7 +292,8 @@
           >
             <div class="basis-2/5 text-center md:text-left">
               <h3 class="text-2xl sm:text-3xl large-heading">
-                Scaling <i>beyond</i> geospatial tech
+                Scaling <i>beyond</i><br />
+                geospatial tech
               </h3>
               <p class="large-body leading-8 my-7">
                 Raster Vision is versatile and can seamlessly handle the
@@ -308,23 +309,43 @@
               >
             </div>
             <div
-              class="flex display text-3xl sm:text-4xl md:text-3xl lg:text-4xl h-48 overflow-hidden tracking-tight align-middle justify-center m-auto"
+              class="flex display text-3.5xl sm:text-4xl h-48 overflow-hidden tracking-tight align-middle justify-center m-auto"
             >
               <!-- add bars to highlight only middle word in rolodex -->
               <div class="rolodex-bars"></div>
               <div class="rolodex-bars mt-24 rotate-180"></div>
-              <ul class="animate-rolodex text-center z-20">
+              <!-- wrapping breaks the animation, so adding a safeguard just in case -->
+              <ul class="animate-rolodex text-center z-20 whitespace-nowrap">
                 <li>Forestry</li>
                 <li>Healthcare</li>
                 <li>Academia</li>
                 <li>Supply Chain</li>
-                <li>Energy Transition</li>
-                <li>Oceans & Water</li>
-                <!-- this shouldn't ever wrap but if it does, the animation breaks, so adding a safeguard just in case -->
-                <li class="whitespace-nowrap">Climate Adaptation</li>
+                <li class="hidden sm:block md:hidden lg:block">
+                  Energy Transition
+                </li>
+                <li class="sm:hidden md:block lg:hidden" aria-hidden="true">
+                  Clean Energy
+                </li>
+                <li class="hidden sm:block md:hidden lg:block">
+                  Oceans & Water
+                </li>
+                <li class="sm:hidden md:block lg:hidden" aria-hidden="true">
+                  Waterways
+                </li>
+                <li class="hidden sm:block md:hidden lg:block">
+                  Climate Adaptation
+                </li>
+                <li class="sm:hidden md:block lg:hidden" aria-hidden="true">
+                  Climate
+                </li>
                 <li>Non-profit</li>
                 <li>Agriculture</li>
-                <li class="whitespace-nowrap">Artificial Intelligence</li>
+                <li class="hidden sm:block md:hidden lg:block">
+                  Artificial Intelligence
+                </li>
+                <li class="sm:hidden md:block lg:hidden" aria-hidden="true">
+                  AI
+                </li>
                 <li>Forestry</li>
                 <li>Healthcare</li>
                 <li>Academia</li>

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -46,6 +46,7 @@ module.exports = {
       lg: "1.125rem",
       "2xl": "1.5rem",
       "3xl": "2rem",
+      "3.5xl": "2.75rem",
       "4xl": "3.125rem",
     },
     textColor: {
@@ -123,7 +124,7 @@ module.exports = {
         },
       },
       animation: {
-        rolodex: "roll 30s cubic-bezier(.75,0,.25,1) infinite",
+        rolodex: "roll 20s cubic-bezier(.75,0,.25,1) infinite",
       },
     },
   },


### PR DESCRIPTION
**Overview**

This PR updates the rolodex effect and content in the industry section. It increases the speed of the rolodex effect and updates its responsiveness by displaying shorter industry names on mobile and medium-sized screens, instead of shrinking on those screen sizes. These shorter names remain as their long versions on small and large screens. The text also shrinks slightly on mobile screens.

In order to make this change friendly to assistive technologies, I added `aria-hidden="true"` to both the long and short variations of each industry name and added screen-reader-only versions of the long version of each that will make sure the list includes those industries regardless of screen sizes.

**Demo**

_The rolodex on large screens_
![Screenshot 2023-01-11 at 2 44 56 PM](https://user-images.githubusercontent.com/77936689/211903050-acdcfc60-0e55-491e-9f54-a2fadbb56d54.png)

_The rolodex on medium screens, demonstrating two of the shorter phrases_
![Screenshot 2023-01-11 at 2 45 16 PM](https://user-images.githubusercontent.com/77936689/211903126-f3cd420d-e69a-428d-8f44-af2ab0f30f5d.png)


Resolves #39 