### PR TITLE
Fix fonts to more closely match designs

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -408,7 +408,7 @@
                   Offers a complete training pipeline for three computer vision
                   tasks
                 </h4>
-                <p>
+                <p class="tech-spec-description text-white">
                   Including chip classification, object detection, and semantic
                   segmentation.
                 </p>
@@ -422,7 +422,7 @@
                 <h4 class="font-semibold text-med">
                   Produces georeferenced outputs
                 </h4>
-                <p>
+                <p class="tech-spec-description text-white">
                   Raster Vision produces predictions that are georeferenced and
                   ready for downstream analysis.
                 </p>
@@ -436,7 +436,7 @@
                 <h4 class="font-semibold text-med">
                   Restrict training chips to an area or interest (AOI)
                 </h4>
-                <p>
+                <p class="tech-spec-description text-white">
                   Fully annotating a large pixel scene is costly and time
                   consuming. Raster Vision supports specifying an AOI in the
                   form of one or more polygons.
@@ -451,7 +451,7 @@
                 <h4 class="font-semibold text-med">
                   Facilitates data wrangling
                 </h4>
-                <p>
+                <p class="tech-spec-description text-white">
                   Raster Vision can ingest both raster and vector data and
                   convert them to a form suitable for training.
                 </p>
@@ -466,7 +466,7 @@
                   Supports multiband imagery (eg. RGBIR images, Sentinel 2
                   imagery)
                 </h4>
-                <p>
+                <p class="tech-spec-description text-white">
                   While retaining the existing pre-trained weights, Raster
                   Vision modifies the first convolutional layer to accept
                   additional (or fewer) channels.
@@ -479,7 +479,7 @@
                   aria-hidden="true"
                 />
                 <h4 class="font-semibold text-med">Offers data augmentation</h4>
-                <p>
+                <p class="tech-spec-description text-white">
                   Raster Vision supports customizable Albumentations transforms
                   to use during training.
                 </p>
@@ -493,7 +493,7 @@
                 <h4 class="font-semibold text-med">
                   Custom model specification
                 </h4>
-                <p>
+                <p class="tech-spec-description text-white">
                   Utilize a wide variety of compatible models from local
                   directories using TorchHub.
                 </p>
@@ -505,7 +505,7 @@
                   aria-hidden="true"
                 />
                 <h4 class="font-semibold text-med">Based on PyTorch</h4>
-                <p>
+                <p class="tech-spec-description text-white">
                   Raster Vision implements deep learning functionality with
                   PyTorch (a popular deep learning library) and Torchvision.
                 </p>
@@ -519,7 +519,7 @@
                 <h4 class="font-semibold text-med">
                   Supports running pipelines in the cloud
                 </h4>
-                <p>
+                <p class="tech-spec-description text-white">
                   Raster Vision provides support for running pipelines using AWS
                   Batch.
                 </p>
@@ -533,7 +533,7 @@
                 <h4 class="font-semibold text-med">
                   Supports configurable chip reading
                 </h4>
-                <p>
+                <p class="tech-spec-description text-white">
                   Geospatial images tend to be too large to feed directly into a
                   neural network and must first be broken up into smaller
                   “chips”.
@@ -648,7 +648,7 @@
                   aria-hidden="true"
                 />
                 <h4 class="why-use-headline"><strong>Customizable</strong></h4>
-                <p class="xsmall-body text-gray-700">
+                <p class="small-body text-gray-700">
                   Utilize custom datasets, model architectures, and arbitrary
                   loss functions.
                 </p>
@@ -662,7 +662,7 @@
                 <h4 class="why-use-headline">
                   <strong>Repeatable, configurable workflow</strong>
                 </h4>
-                <p class="xsmall-body text-gray-700">
+                <p class="small-body text-gray-700">
                   Create consistent and maintainable results.
                 </p>
               </div>
@@ -673,7 +673,7 @@
                   aria-hidden="true"
                 />
                 <h4 class="why-use-headline"><strong>Open source</strong></h4>
-                <p class="xsmall-body text-gray-700">
+                <p class="small-body text-gray-700">
                   Benefit from a constantly updated & supported framework
                   released under the open source Apache 2.0 license.
                 </p>
@@ -687,7 +687,7 @@
                 <h4 class="why-use-headline">
                   <strong>Handles geospatial datasets</strong>
                 </h4>
-                <p class="xsmall-body text-gray-700">
+                <p class="small-body text-gray-700">
                   Handles a variety of geospatial file formats, map-based
                   coordinates, incomplete labeling, and multiband (3+ bands)
                   imagery.
@@ -702,7 +702,7 @@
                 <h4 class="why-use-headline">
                   <strong>Supports massive imagery</strong>
                 </h4>
-                <p class="xsmall-body text-gray-700">
+                <p class="small-body text-gray-700">
                   Works out-of-the-box with massive imagery commonly used in the
                   geospatial field.
                 </p>
@@ -716,7 +716,7 @@
                 <h4 class="why-use-headline">
                   <strong>Low barrier to entry</strong>
                 </h4>
-                <p class="xsmall-body text-gray-700">
+                <p class="small-body text-gray-700">
                   Enjoy a high-level programmatic API with sensible defaults for
                   configuring modeling pipelines. Doesn't require expertise in
                   PyTorch or deep learning.
@@ -731,7 +731,7 @@
                 <h4 class="why-use-headline">
                   <strong>Fast AWS Batch setup process</strong>
                 </h4>
-                <p class="xsmall-body text-gray-700">
+                <p class="small-body text-gray-700">
                   Skip the manual setup and use CloudFormation templates.
                 </p>
               </div>
@@ -744,7 +744,7 @@
                 <h4 class="why-use-headline">
                   <strong>Extensible architecture</strong>
                 </h4>
-                <p class="xsmall-body text-gray-700">
+                <p class="small-body text-gray-700">
                   Object-oriented architecture is extendable to new computer
                   vision tasks and deep learning frameworks.
                 </p>

--- a/src/index.html
+++ b/src/index.html
@@ -22,7 +22,7 @@
       rel="stylesheet"
     />
     <link
-      href="https://fonts.googleapis.com/css2?family=Poppins:wght@600&display=swap"
+      href="https://fonts.googleapis.com/css2?family=Poppins:wght@500&display=swap"
       rel="stylesheet"
     />
     <link rel="stylesheet" href="dist/output.css" />
@@ -56,14 +56,14 @@
         <div class="flex flex-row items-center">
           <a href="https://github.com/azavea/raster-vision/discussions">
             <div
-              class="hidden sm:flex text-gray-700 font-semibold hover:underline mr-1.5 md:mr-6 text-center"
+              class="hidden sm:flex text-gray-700 font-medium hover:underline mr-1.5 md:mr-6 text-center"
             >
               Github Discussions
             </div>
           </a>
           <a href="https://docs.rastervision.io/">
             <div
-              class="hidden sm:flex text-gray-700 font-semibold hover:underline mr-1.5 md:mr-6"
+              class="hidden sm:flex text-gray-700 font-medium hover:underline mr-1.5 md:mr-6"
             >
               Documentation
             </div>
@@ -73,8 +73,8 @@
               <div
                 class="w-24 md:w-32 h-6 sm:h-8 flex justify-center align-middle"
               >
-                <div class="m-auto text-med md:text-lg font-semibold">
-                  Get started
+                <div class="m-auto text-med md:text-lg font-medium">
+                  Get Started
                 </div>
               </div>
             </div>
@@ -179,7 +179,7 @@
         <div class="max-width-container">
           <div class="mt-14 sm:flex sm:flex-row sm:mt-0 gap-10">
             <div class="basis-1/2 my-auto">
-              <h2 class="large-heading text-2xl text-white mb-6 md:text-3xl">
+              <h2 class="large-headline text-2xl text-white mb-6 md:text-3xl">
                 Build intelligent <i>geospatial</i> applications with deep
                 learning.
               </h2>
@@ -301,7 +301,7 @@
             class="flex flex-col-reverse md:flex-row justify-between my-6 sm:my-10 md:my-20 gap-6"
           >
             <div class="basis-2/5 text-center md:text-left">
-              <h3 class="text-2xl sm:text-3xl large-heading">
+              <h3 class="text-2xl sm:text-3xl large-headline">
                 Scaling <i>beyond</i><br />
                 geospatial tech
               </h3>
@@ -388,7 +388,7 @@
           <div class="flex justify-center py-4">
             <button
               id="spec-button"
-              class="sm:hidden text-white border-gray-300 w-80 border-opacity-10 border-1 py-2 px-10 font-semibold"
+              class="sm:hidden text-white border-gray-300 w-80 border-opacity-10 border-1 py-2 px-10 font-medium"
             >
               See more specs
             </button>
@@ -404,7 +404,7 @@
                   class="tech-spec-icon"
                   aria-hidden="true"
                 />
-                <h4 class="font-semibold text-med">
+                <h4 class="font-medium text-med">
                   Offers a complete training pipeline for three computer vision
                   tasks
                 </h4>
@@ -419,7 +419,7 @@
                   class="tech-spec-icon"
                   aria-hidden="true"
                 />
-                <h4 class="font-semibold text-med">
+                <h4 class="font-medium text-med">
                   Produces georeferenced outputs
                 </h4>
                 <p class="tech-spec-description text-white">
@@ -433,7 +433,7 @@
                   class="tech-spec-icon"
                   aria-hidden="true"
                 />
-                <h4 class="font-semibold text-med">
+                <h4 class="font-medium text-med">
                   Restrict training chips to an area or interest (AOI)
                 </h4>
                 <p class="tech-spec-description text-white">
@@ -448,9 +448,7 @@
                   class="tech-spec-icon"
                   aria-hidden="true"
                 />
-                <h4 class="font-semibold text-med">
-                  Facilitates data wrangling
-                </h4>
+                <h4 class="font-medium text-med">Facilitates data wrangling</h4>
                 <p class="tech-spec-description text-white">
                   Raster Vision can ingest both raster and vector data and
                   convert them to a form suitable for training.
@@ -462,7 +460,7 @@
                   class="tech-spec-icon"
                   aria-hidden="true"
                 />
-                <h4 class="font-semibold text-med">
+                <h4 class="font-medium text-med">
                   Supports multiband imagery (eg. RGBIR images, Sentinel 2
                   imagery)
                 </h4>
@@ -478,7 +476,7 @@
                   class="tech-spec-icon"
                   aria-hidden="true"
                 />
-                <h4 class="font-semibold text-med">Offers data augmentation</h4>
+                <h4 class="font-medium text-med">Offers data augmentation</h4>
                 <p class="tech-spec-description text-white">
                   Raster Vision supports customizable Albumentations transforms
                   to use during training.
@@ -490,9 +488,7 @@
                   class="tech-spec-icon"
                   aria-hidden="true"
                 />
-                <h4 class="font-semibold text-med">
-                  Custom model specification
-                </h4>
+                <h4 class="font-medium text-med">Custom model specification</h4>
                 <p class="tech-spec-description text-white">
                   Utilize a wide variety of compatible models from local
                   directories using TorchHub.
@@ -504,7 +500,7 @@
                   class="tech-spec-icon"
                   aria-hidden="true"
                 />
-                <h4 class="font-semibold text-med">Based on PyTorch</h4>
+                <h4 class="font-medium text-med">Based on PyTorch</h4>
                 <p class="tech-spec-description text-white">
                   Raster Vision implements deep learning functionality with
                   PyTorch (a popular deep learning library) and Torchvision.
@@ -516,7 +512,7 @@
                   class="tech-spec-icon"
                   aria-hidden="true"
                 />
-                <h4 class="font-semibold text-med">
+                <h4 class="font-medium text-med">
                   Supports running pipelines in the cloud
                 </h4>
                 <p class="tech-spec-description text-white">
@@ -530,7 +526,7 @@
                   class="tech-spec-icon"
                   aria-hidden="true"
                 />
-                <h4 class="font-semibold text-med">
+                <h4 class="font-medium text-med">
                   Supports configurable chip reading
                 </h4>
                 <p class="tech-spec-description text-white">
@@ -647,7 +643,7 @@
                   src="images/why-use-customizable.jpg"
                   aria-hidden="true"
                 />
-                <h4 class="why-use-headline"><strong>Customizable</strong></h4>
+                <h4 class="why-use-headline">Customizable</h4>
                 <p class="small-body text-gray-700">
                   Utilize custom datasets, model architectures, and arbitrary
                   loss functions.
@@ -660,7 +656,7 @@
                   aria-hidden="true"
                 />
                 <h4 class="why-use-headline">
-                  <strong>Repeatable, configurable workflow</strong>
+                  Repeatable, configurable workflow
                 </h4>
                 <p class="small-body text-gray-700">
                   Create consistent and maintainable results.
@@ -672,7 +668,7 @@
                   src="images/why-use-opensource.jpg"
                   aria-hidden="true"
                 />
-                <h4 class="why-use-headline"><strong>Open source</strong></h4>
+                <h4 class="why-use-headline">Open source</h4>
                 <p class="small-body text-gray-700">
                   Benefit from a constantly updated & supported framework
                   released under the open source Apache 2.0 license.
@@ -684,9 +680,7 @@
                   src="images/why-use-geodatasets.jpg"
                   aria-hidden="true"
                 />
-                <h4 class="why-use-headline">
-                  <strong>Handles geospatial datasets</strong>
-                </h4>
+                <h4 class="why-use-headline">Handles geospatial datasets</h4>
                 <p class="small-body text-gray-700">
                   Handles a variety of geospatial file formats, map-based
                   coordinates, incomplete labeling, and multiband (3+ bands)
@@ -699,9 +693,7 @@
                   src="images/why-use-massiveimgagery.jpg"
                   aria-hidden="true"
                 />
-                <h4 class="why-use-headline">
-                  <strong>Supports massive imagery</strong>
-                </h4>
+                <h4 class="why-use-headline">Supports massive imagery</h4>
                 <p class="small-body text-gray-700">
                   Works out-of-the-box with massive imagery commonly used in the
                   geospatial field.
@@ -713,9 +705,7 @@
                   src="images/why-use-lowbarrier.jpg"
                   aria-hidden="true"
                 />
-                <h4 class="why-use-headline">
-                  <strong>Low barrier to entry</strong>
-                </h4>
+                <h4 class="why-use-headline">Low barrier to entry</h4>
                 <p class="small-body text-gray-700">
                   Enjoy a high-level programmatic API with sensible defaults for
                   configuring modeling pipelines. Doesn't require expertise in
@@ -728,9 +718,7 @@
                   src="images/why-use-fastaws.jpg"
                   aria-hidden="true"
                 />
-                <h4 class="why-use-headline">
-                  <strong>Fast AWS Batch setup process</strong>
-                </h4>
+                <h4 class="why-use-headline">Fast AWS Batch setup process</h4>
                 <p class="small-body text-gray-700">
                   Skip the manual setup and use CloudFormation templates.
                 </p>
@@ -741,9 +729,7 @@
                   src="images/why-use-extensible.jpg"
                   aria-hidden="true"
                 />
-                <h4 class="why-use-headline">
-                  <strong>Extensible architecture</strong>
-                </h4>
+                <h4 class="why-use-headline">Extensible architecture</h4>
                 <p class="small-body text-gray-700">
                   Object-oriented architecture is extendable to new computer
                   vision tasks and deep learning frameworks.
@@ -757,7 +743,7 @@
     <section>
       <div class="bg-white-0">
         <div class="max-width-container sm:mt-10">
-          <h2 class="text-lg text-center mb-12 sm:mb-7 md:text-2xl">
+          <h2 class="text-lg font-light text-center mb-12 sm:mb-7 md:text-2xl">
             Easily use models in various deployment scenarios
           </h2>
           <div class="md:flex md:flex-row gap-x-4 lg:mx-12">
@@ -834,7 +820,7 @@
                         <div
                           class="flex rounded bg-gray-800 w-56 h-10 md:h-8 lg:h-10 justify-center"
                         >
-                          <div class="m-auto font-semibold text-white">
+                          <div class="m-auto font-medium text-white">
                             View full documentation
                           </div>
                         </div>

--- a/src/input.css
+++ b/src/input.css
@@ -60,6 +60,10 @@
     @apply h-28 w-32 flex justify-center items-center;
   }
 
+  .tech-spec-description {
+    @apply small-body mt-2;
+  }
+
   .hero-image {
     @apply absolute bottom-0 -rotate-90 object-left object-cover sm:h-hero sm:transform-none;
   }

--- a/src/input.css
+++ b/src/input.css
@@ -1,30 +1,30 @@
 @import "tailwindcss/base";
 .xsmall-body {
-  @apply font-normal text-xs text-gray-800;
+  @apply font-light text-xs text-gray-800;
 }
 
 .small-body {
-  @apply font-normal text-sm text-gray-800;
+  @apply font-light text-sm text-gray-800;
 }
 
 .medium-body {
-  @apply font-normal text-med text-gray-800;
+  @apply font-light text-med text-gray-800;
 }
 
 .large-body {
-  @apply font-normal text-lg text-gray-800;
+  @apply font-light text-lg text-gray-800;
 }
 
 .display {
-  @apply font-normal text-4xl leading-display text-teal;
+  @apply font-light text-4xl leading-display text-teal;
 }
 
 .large-headline {
-  @apply font-normal text-3xl text-black;
+  @apply font-light text-3xl text-black;
 }
 
 .medium-headline {
-  @apply font-normal text-2xl text-black;
+  @apply font-light text-2xl text-black;
 }
 
 .small-headline {
@@ -41,7 +41,7 @@
   }
 
   .secondary-btn {
-    @apply rounded bg-white-0 text-black border-gray-300 border-1 p-2 hover:bg-gray-100 font-semibold;
+    @apply rounded bg-white-0 text-black border-gray-300 border-1 p-2 hover:bg-gray-100 font-medium;
   }
 
   .max-width-container {
@@ -77,11 +77,11 @@
   }
 
   .why-use-headline {
-    @apply text-med font-semibold text-black mt-3 mb-1;
+    @apply text-med font-medium text-black mt-3 mb-1;
   }
 
   .repeatable-config-selection {
-    @apply rounded-md bg-white-0 text-black border-gray-300 border-1 p-2 font-semibold h-10 text-med text-left hover:cursor-pointer;
+    @apply rounded-md bg-white-0 text-black border-gray-300 border-1 p-2 font-medium h-10 text-med text-left hover:cursor-pointer;
   }
 
   .repeatable-config-button-container {


### PR DESCRIPTION
**Overview**

This PR increases the size of the paragraph text in the Technical Specifications and "Why Use Raster Vision" sections. It also decreases the weight of the bolded text everywhere but on the two smallest headlines, `small-headline` and `small-headline-all-caps` (those 2 looked too similar to regular text at weight 500). 

**Notes**

Importing weight 500 instead of 600 resulted in the bolding of all fonts with the `font-normal` class (weight 400) for some reason. As a result, I've also decreased the weight of all non-bolded fonts to `font-light` to match the imported weight of 300.

Resolves #40 