### PR TITLE
Fix contact us name spacing on Firefox & README update

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,3 +13,5 @@ The redesigned marketing site for the Raster Vision repo.
 To compile the code with Tailwind CSS and update on style change, run `npm run compile-css`.
 
 In another tab, start the server by running `npm start`. View at localhost:8000. Refresh to see changes.
+
+As a note, there is no staging site and all GitHub Actions builds (including test branches, PRs, and merges into `master`) will be deployed to the live site.

--- a/src/index.html
+++ b/src/index.html
@@ -950,8 +950,8 @@
                 id="contact-form"
               >
                 <div class="flex flex-col gap-y-4">
-                  <div class="sm:flex sm:flex-row sm:justify-between gap-4">
-                    <div class="contact-us-form-section w-full">
+                  <div class="md:flex md:flex-row sm:justify-between gap-4">
+                    <div class="contact-us-form-section">
                       <label for="first_name" class="text-white"
                         >First name*</label
                       >
@@ -959,11 +959,11 @@
                         type="text"
                         id="first_name"
                         name="first_name"
-                        class="contact-us-input"
+                        class="contact-us-input md:w-contact-us-name"
                         required="required"
                       />
                     </div>
-                    <div class="contact-us-form-section w-full pt-4 sm:pt-0">
+                    <div class="contact-us-form-section pt-4 md:pt-0">
                       <label for="last_name" class="text-white"
                         >Last name*</label
                       >
@@ -971,7 +971,7 @@
                         type="text"
                         id="last_name"
                         name="last_name"
-                        class="contact-us-input"
+                        class="contact-us-input md:w-contact-us-name"
                         required="required"
                       />
                     </div>

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -98,6 +98,7 @@ module.exports = {
         hero: "775px",
         "hero-button": "35px",
         "header-text": "50%",
+        "contact-us-name": "214px"
       },
       margin: {
         "hero-button-arrow": "11px",


### PR DESCRIPTION
**Overview**

This PR fixes the spacing of the first name/last name fields in the contact form on Firefox so that the last name field does not overflow onto the "How can we help?" text. It also includes an update to the `README` to warn that there is no staging site and that all changes built by GitHub Actions will be deployed to the live site.

**Notes**

The difference in the appearance of the contact form between Chrome and Firefox seemed to come down to how each interpreted `width: 100%`. While this worked to allow the two fields to stretch to fit the available space on Chrome, Firefox interpreted this to mean that the fields should be allowed to stretch beyond the available space. I found that on medium+  (>767px) screens, the form does not change width, so I was able to get the form to look right on both browsers by setting a specific max width on both fields; however, I could not find a solution that worked for both for screens between mobile (<640px) and medium because the total width of the form changed but the two fields still stayed in a flex row. As a result, I found the easiest way to fix the issue was simply to keep the fields stacked on mobile and small screens and then become a flew row on medium when the form is given a static width.

Resolves #55 