### PR TITLE
Remove pull request GitHub Actions workflow trigger

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,7 +5,6 @@ on:
     branches:
       - master
       - test/**
-  pull_request:
   workflow_dispatch:
 
 jobs:

--- a/README.md
+++ b/README.md
@@ -14,4 +14,4 @@ To compile the code with Tailwind CSS and update on style change, run `npm run c
 
 In another tab, start the server by running `npm start`. View at localhost:8000. Refresh to see changes.
 
-As a note, there is no staging site and all GitHub Actions builds (including test branches, PRs, and merges into `master`) will be deployed to the live site.
+As a note, there is no staging site and all GitHub Actions builds (including test branches and merges into `master`) will be deployed to the live site.


### PR DESCRIPTION
**Overview**

This PR removes the automatic GitHub workflow trigger to build from PRs. 

**Testing**
- [x] Doesn't build on creation of this PR
- [x] Still builds if run as test branch
- [ ] Still builds when merged

Resolves #60 